### PR TITLE
Free resources (fixes some leaks)

### DIFF
--- a/pystassh/api.py
+++ b/pystassh/api.py
@@ -23,6 +23,7 @@ def _init_api():
     lib = ffi.dlopen(lib_name)
     ffi.cdef("""
         void* ssh_new();
+        int ssh_free(void*);
         int ssh_options_set(void*, int, char*);
         int ssh_connect(void*);
         int ssh_disconnect(void*);

--- a/pystassh/channel.py
+++ b/pystassh/channel.py
@@ -35,6 +35,7 @@ class Channel:
 
         ret = api.Api.ssh_channel_open_session(channel)
         if ret != api.SSH_OK:
+            api.Api.ssh_channel_free(channel)
             raise exceptions.ChannelException("Channel cannot be opened: {}".format(self.get_error_message()))
 
         self._channel = channel

--- a/pystassh/session.py
+++ b/pystassh/session.py
@@ -29,6 +29,10 @@ class Session:
             passphrase (str): optionnal passphrase to be used with a public key authentication
             port (int): SSH remote port
         """
+        # Keep a reference to the Api class so we can access it from __del__().
+        # During the deinitialization of the Python VM, the module 'api' may not
+        # be available so we have to keep a reference to the Api class.
+        self._api = api.Api
         self._hostname = str.encode(hostname)
         self._username = str.encode(username)
         self._password = str.encode(password)
@@ -44,7 +48,7 @@ class Session:
         Returns:
             bool: A boolean indicating whether or not the connexion is currently active.
         """
-        return bool(self._session and api.Api.ssh_is_connected(self._session))
+        return bool(self._session and self._api.ssh_is_connected(self._session))
 
     def connect(self):
 
@@ -57,39 +61,39 @@ class Session:
         if self.is_connected():
             return
 
-        session = api.Api.ssh_new()
+        session = self._api.ssh_new()
         if session is None:
             raise exceptions.ConnectionException("Session cannot be created: {}".format(self.get_error_message()))
 
         try:
-            ret = api.Api.ssh_options_set(session, api.SSH_OPTIONS_HOST, self._hostname)
+            ret = self._api.ssh_options_set(session, api.SSH_OPTIONS_HOST, self._hostname)
             if ret != api.SSH_OK:
                 raise exceptions.ConnectionException("Hostname '{}' cannot be set (return code: {}): {}".format(
                     self._hostname, ret, self.get_error_message(session)))
 
-            ret = api.Api.ssh_options_set(session, api.SSH_OPTIONS_PORT_STR, self._port)
+            ret = self._api.ssh_options_set(session, api.SSH_OPTIONS_PORT_STR, self._port)
             if ret != api.SSH_OK:
                 raise exceptions.ConnectionException("Port '{}' cannot be set (return code: {}): {}".format(
                     self._port, ret, self.get_error_message(session)))
 
-            ret = api.Api.ssh_options_set(session, api.SSH_OPTIONS_USER, self._username)
+            ret = self._api.ssh_options_set(session, api.SSH_OPTIONS_USER, self._username)
             if ret != api.SSH_OK:
                 raise exceptions.ConnectionException("Username '{}' cannot be set (return code: {}): {}".format(
                     self._username, ret, self.get_error_message(session)))
 
-            ret = api.Api.ssh_connect(session)
+            ret = self._api.ssh_connect(session)
             if ret != api.SSH_OK:
                 raise exceptions.ConnectionException("Connection cannot be made (return code: {}): {}".format(
                     ret, self.get_error_message(session)))
 
             if self._password:
-                ret = api.Api.ssh_userauth_password(session, self._username, self._password)
+                ret = self._api.ssh_userauth_password(session, self._username, self._password)
                 if ret != api.SSH_AUTH_SUCCESS:
                     raise exceptions.AuthenticationException(
                         "Authentication cannot be made with username and password (return code: {}): {}".format(
                             ret, self.get_error_message(session)))
             else:
-                ret = api.Api.ssh_userauth_autopubkey(session, self._passphrase)
+                ret = self._api.ssh_userauth_autopubkey(session, self._passphrase)
                 if ret != api.SSH_AUTH_SUCCESS:
                     raise exceptions.AuthenticationException(
                         "Authentication cannot be made with public key (return code: {}): {}".format(
@@ -98,7 +102,7 @@ class Session:
             self._session = session
             self._channel = Channel(self._session)
         except:
-            api.Api.ssh_free(session)
+            self._api.ssh_free(session)
             self._session = self._channel = None
             raise
 
@@ -107,8 +111,8 @@ class Session:
         """
         if self.is_connected():
             self._channel.close()
-            api.Api.ssh_disconnect(self._session)
-            api.Api.ssh_free(self._session)
+            self._api.ssh_disconnect(self._session)
+            self._api.ssh_free(self._session)
         self._channel = None
         self._session = None
 
@@ -132,6 +136,10 @@ class Session:
     def __exit__(self, *_):
         self.disconnect()
 
+    def __del__(self):
+        self.disconnect()
+        del self._api
+
     def get_error_message(self, session=None):
         """ Tries to retrieve an error message in case of error.
 
@@ -142,6 +150,6 @@ class Session:
         """
         session = session or self._session
         try:
-            return api.Api.get_error_message(session)
+            return self._api.get_error_message(session)
         except exceptions.UnknownException:
             return "<error message irrecoverable>"

--- a/pystassh/session.py
+++ b/pystassh/session.py
@@ -101,7 +101,9 @@ class Session:
         """ Close the current connection.
         """
         if self.is_connected():
+            self._channel.close()
             api.Api.ssh_disconnect(self._session)
+        self._channel = None
         self._session = None
 
     def execute(self, command):

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -40,64 +40,78 @@ def test_channel_is_open(monkeypatch, patched_channel):
 def test_channel_open(monkeypatch, patched_channel):
 
     import pystassh.api
+    fake_ssh_channel_free = MagicMock()
     channel = patched_channel("<session object>")
     monkeypatch.setattr("pystassh.api.Api.ssh_channel_new", lambda *_: "<channel object>")
+    monkeypatch.setattr("pystassh.api.Api.ssh_channel_free", fake_ssh_channel_free)
     monkeypatch.setattr("pystassh.api.Api.ssh_channel_open_session", lambda *_: pystassh.api.SSH_OK)
     monkeypatch.setattr("pystassh.channel.Channel._is_open", lambda self: bool(self._channel))
 
     channel.open()
     assert channel._channel == "<channel object>"
+    fake_ssh_channel_free.assert_not_called()
 
     monkeypatch.setattr("pystassh.api.Api.ssh_channel_new", lambda *_: "<new channel object>")
     channel.open()
     assert channel._channel == "<channel object>"
     channel._channel = None
+    fake_ssh_channel_free.assert_not_called()
 
     channel.open()
     assert channel._channel == "<new channel object>"
+    fake_ssh_channel_free.assert_not_called()
 
 
 def test_channel_open_ssh_channel_new_error(monkeypatch, patched_channel):
 
     import pystassh.exceptions
+    fake_ssh_channel_free = MagicMock()
     channel = patched_channel("<session object>")
     monkeypatch.setattr("pystassh.api.Api.ssh_channel_new", lambda *_: None)
+    monkeypatch.setattr("pystassh.api.Api.ssh_channel_free", fake_ssh_channel_free)
     monkeypatch.setattr("pystassh.channel.Channel._is_open", lambda self: bool(self._channel))
 
     with pytest.raises(pystassh.exceptions.ChannelException):
         channel.open()
     assert channel._channel is None
+    fake_ssh_channel_free.assert_not_called()
 
 
 def test_channel_open_ssh_channel_open_session_error(monkeypatch, patched_channel):
 
     import pystassh.exceptions
+    fake_ssh_channel_free = MagicMock()
     channel = patched_channel("<session object>")
     monkeypatch.setattr("pystassh.api.Api.ssh_channel_new", lambda *_: "<channel object>")
+    monkeypatch.setattr("pystassh.api.Api.ssh_channel_free", fake_ssh_channel_free)
     monkeypatch.setattr("pystassh.api.Api.ssh_channel_open_session", lambda *_: -1)
     monkeypatch.setattr("pystassh.channel.Channel._is_open", lambda self: bool(self._channel))
 
     with pytest.raises(pystassh.exceptions.ChannelException):
         channel.open()
     assert channel._channel is None
+    fake_ssh_channel_free.assert_called_once_with("<channel object>")
 
 
 def test_channel_close(monkeypatch, patched_channel):
 
     import pystassh.api
+    fake_ssh_channel_free = MagicMock(return_value=pystassh.api.SSH_OK)
     channel = patched_channel("<session object>")
+    monkeypatch.setattr("pystassh.api.Api.ssh_channel_free", fake_ssh_channel_free)
     monkeypatch.setattr("pystassh.channel.Channel._is_open", lambda *_: False)
 
     channel._channel = "<channel object>"
     channel.close()
     assert channel._channel is None
+    fake_ssh_channel_free.assert_not_called()
 
     monkeypatch.setattr("pystassh.channel.Channel._is_open", lambda *_: True)
     monkeypatch.setattr("pystassh.api.Api.ssh_channel_send_eof", lambda *_: pystassh.api.SSH_OK)
-    monkeypatch.setattr("pystassh.api.Api.ssh_channel_free", lambda *_: pystassh.api.SSH_OK)
     channel._channel = "<channel object>"
     channel.close()
     assert channel._channel is None
+    fake_ssh_channel_free.assert_called_once_with("<channel object>")
 
 
 def test_channel_with_block(monkeypatch, patched_channel):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -151,20 +151,28 @@ def test_session_connect_ssh_userauth_autopubkey_error(monkeypatch, patched_sess
 
 
 def test_session_disconnect(monkeypatch, patched_session):
-
     import pystassh.api
     session = patched_session()
+    channel = MagicMock()
     monkeypatch.setattr("pystassh.session.Session.is_connected", lambda *_: False)
 
     session._session = "<session object>"
+    session._channel = channel
     session.disconnect()
     assert session._session is None
+    assert session._channel is None
+    channel.close.assert_not_called()
+
+    channel.reset_mock()
 
     monkeypatch.setattr("pystassh.session.Session.is_connected", lambda *_: True)
     monkeypatch.setattr("pystassh.api.Api.ssh_disconnect", lambda *_: pystassh.api.SSH_OK)
     session._session = "<session object>"
+    session._channel = channel
     session.disconnect()
     assert session._session is None
+    assert session._channel is None
+    channel.close.assert_called_once_with()
 
 
 def test_session_with_block(monkeypatch, patched_session):


### PR DESCRIPTION
# PR summary

 - Added some calls to `ssh_channel_free` and `ssh_free` and fixed some leaks.
 - Added the corresponding unit tests.

# Context

Doing a review I found a few possible leaks:
 - a possible leak of the `channel` if the `open` alloc'ed the channel but failed later.
 - a leak of the `session` (there is a missing call to `ssh_free` after the `disconnect`)
 - a possible leak of the `session` if the user does not use its context manager and call explicitly `connect` without calling `disconnect` (`session` does not call `disconnect` when it is garbage-collected)

The proposed PR makes the explicit calls to the respective "free" functions. I thought use cffi's `gc` function to link a "free" function to the `session` and `channel` objects *coming from C* but cffi does not make any guaranty about the *order* of the destruction so it could happen that the `session` being destroyed *before* the `channel`.
(references: [cffi-issue-340](https://foss.heptapod.net/pypy/cffi/-/issues/340) and [cffi-doc-gc](https://cffi.readthedocs.io/en/latest/ref.html#ffi-gc) )

It's possible, with some care, to make it work but I preferred to make the calls explicit following the current design.

# Additional notes

A lot of thanks about your work. I hope this PR can make it a little better, and let me know what are your thoughts.

Thanks.