### PR TITLE
Free the channel even if it's closed in the libssh sense

### DIFF
--- a/pystassh/channel.py
+++ b/pystassh/channel.py
@@ -47,7 +47,7 @@ class Channel:
 
     def close(self):
         """Close the current channel."""
-        if self._is_open():
+        if self._channel is not None:
             api.Api.ssh_channel_send_eof(self._channel)
             api.Api.ssh_channel_free(self._channel)
         self._shell_requested = False

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -102,17 +102,10 @@ def test_channel_close(monkeypatch, session):
     fake_ssh_channel_free = Mock(return_value=pystassh.api.SSH_OK)
     channel = Channel(session)
     monkeypatch.setattr("pystassh.api.Api.ssh_channel_free", fake_ssh_channel_free)
-    monkeypatch.setattr("pystassh.channel.Channel._is_open", Mock(return_value=False))
-
-    channel._channel = "<channel object>"
-    channel.close()
-    assert channel._channel is None
-    fake_ssh_channel_free.assert_not_called()
-
-    monkeypatch.setattr("pystassh.channel.Channel._is_open", Mock(return_value=True))
     monkeypatch.setattr(
         "pystassh.api.Api.ssh_channel_send_eof", Mock(return_value=pystassh.api.SSH_OK)
     )
+
     channel._channel = "<channel object>"
     channel.close()
     assert channel._channel is None


### PR DESCRIPTION
Fixes #4.

I'm a little bit unsure about `send_eof` on a channel that's 'closed'; it doesn't seem to cause any trouble locally though. I think the important part is freeing the channel.